### PR TITLE
fix: update RPC endpoint

### DIFF
--- a/src/configs/shared.ts
+++ b/src/configs/shared.ts
@@ -23,7 +23,7 @@ export const DEFAULT_FOLLOWUP_TIME = "4 days"; // 4 days
 export const DEFAULT_DISQUALIFY_TIME = "7 days"; // 7 days
 
 export const DEFAULT_CHAIN_ID = 1;
-export const DEFAULT_RPC_ENDPOINT = "https://rpc-pay.ubq.fi/v1/mainnet";
+export const DEFAULT_RPC_ENDPOINT = "https://rpc-bot.ubq.fi/v1/mainnet";
 export const DEFAULT_PAYMENT_TOKEN = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 export const DEFAULT_PERMIT_BASE_URL = "https://pay.ubq.fi";
 


### PR DESCRIPTION
Regarding https://github.com/ubiquity/ubiquibot/pull/308#discussion_r1195399791

`https` is working fine, try `curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", false],"id":1}' https://rpc-bot.ubq.fi/v1/mainnet`