### PR TITLE
fix: remove PK prefix

### DIFF
--- a/src/utils/private.ts
+++ b/src/utils/private.ts
@@ -8,7 +8,6 @@ import { getAnalyticsMode, getAutoPayMode, getBaseMultiplier, getBountyHunterMax
 const CONFIG_REPO = "ubiquibot-config";
 const KEY_PATH = ".github/ubiquibot-config.yml";
 const KEY_NAME = "private-key-encrypted";
-const KEY_PREFIX = "HSK_";
 
 export const getConfigSuperset = async (context: Context, type: "org" | "repo"): Promise<string | undefined> => {
   try {
@@ -92,7 +91,6 @@ export const getPrivateKey = async (cipherText: string): Promise<string | undefi
     const binCipher = sodium.from_base64(cipherText, sodium.base64_variants.URLSAFE_NO_PADDING);
 
     let walletPrivateKey: string | undefined = sodium.crypto_box_seal_open(binCipher, binPub, binPriv, "text");
-    walletPrivateKey = walletPrivateKey.startsWith(KEY_PREFIX) ? walletPrivateKey.replace(KEY_PREFIX, "") : undefined;
     return walletPrivateKey;
   } catch (error: any) {
     return undefined;

--- a/src/utils/private.ts
+++ b/src/utils/private.ts
@@ -8,6 +8,7 @@ import { getAnalyticsMode, getAutoPayMode, getBaseMultiplier, getBountyHunterMax
 const CONFIG_REPO = "ubiquibot-config";
 const KEY_PATH = ".github/ubiquibot-config.yml";
 const KEY_NAME = "private-key-encrypted";
+const KEY_PREFIX = "HSK_";
 
 export const getConfigSuperset = async (context: Context, type: "org" | "repo"): Promise<string | undefined> => {
   try {
@@ -91,6 +92,7 @@ export const getPrivateKey = async (cipherText: string): Promise<string | undefi
     const binCipher = sodium.from_base64(cipherText, sodium.base64_variants.URLSAFE_NO_PADDING);
 
     let walletPrivateKey: string | undefined = sodium.crypto_box_seal_open(binCipher, binPub, binPriv, "text");
+    walletPrivateKey = walletPrivateKey.replace(KEY_PREFIX, "");
     return walletPrivateKey;
   } catch (error: any) {
     return undefined;


### PR DESCRIPTION
This PR fixes an issue when wallet's private key is `undefined` if there is no `HSK_` prefix.

There is an example config: https://github.com/ubiquity/ubiquibot-config/blob/development/.github/ubiquibot-config.yml

The `private-key-encrypted` field by default doesn't have the `PSK_` prefix. I don't know the original purpose of that prefix but the bot works fine without it.