### PR TITLE
fix: fix permit2 payouts

### DIFF
--- a/src/utils/private.ts
+++ b/src/utils/private.ts
@@ -1,6 +1,5 @@
 import _sodium from "libsodium-wrappers";
 import YAML from "yaml";
-import { getBotConfig } from "../bindings";
 import { Payload } from "../types";
 import { Context } from "probot";
 import { getAnalyticsMode, getAutoPayMode, getBaseMultiplier, getBountyHunterMax, getChainId, getPriorityLabels, getTimeLabels } from "./helpers";
@@ -79,16 +78,14 @@ export const getPrivateKey = async (cipherText: string): Promise<string | undefi
   try {
     await _sodium.ready;
     const sodium = _sodium;
-    const {
-      sodium: { publicKey, privateKey },
-    } = getBotConfig();
+    const publicKey = await getScalarKey(process.env.X25519_PRIVATE_KEY);
 
-    if (publicKey === "" || privateKey === "") {
+    if (!publicKey || !process.env.X25519_PRIVATE_KEY) {
       return undefined;
     }
 
     const binPub = sodium.from_base64(publicKey, sodium.base64_variants.URLSAFE_NO_PADDING);
-    const binPriv = sodium.from_base64(privateKey, sodium.base64_variants.URLSAFE_NO_PADDING);
+    const binPriv = sodium.from_base64(process.env.X25519_PRIVATE_KEY, sodium.base64_variants.URLSAFE_NO_PADDING);
     const binCipher = sodium.from_base64(cipherText, sodium.base64_variants.URLSAFE_NO_PADDING);
 
     let walletPrivateKey: string | undefined = sodium.crypto_box_seal_open(binCipher, binPub, binPriv, "text");

--- a/src/utils/private.ts
+++ b/src/utils/private.ts
@@ -78,14 +78,16 @@ export const getPrivateKey = async (cipherText: string): Promise<string | undefi
   try {
     await _sodium.ready;
     const sodium = _sodium;
-    const publicKey = await getScalarKey(process.env.X25519_PRIVATE_KEY);
 
-    if (!publicKey || !process.env.X25519_PRIVATE_KEY) {
+    const privateKey = process.env.X25519_PRIVATE_KEY;
+    const publicKey = await getScalarKey(privateKey);
+
+    if (!publicKey || !privateKey) {
       return undefined;
     }
 
     const binPub = sodium.from_base64(publicKey, sodium.base64_variants.URLSAFE_NO_PADDING);
-    const binPriv = sodium.from_base64(process.env.X25519_PRIVATE_KEY, sodium.base64_variants.URLSAFE_NO_PADDING);
+    const binPriv = sodium.from_base64(privateKey, sodium.base64_variants.URLSAFE_NO_PADDING);
     const binCipher = sodium.from_base64(cipherText, sodium.base64_variants.URLSAFE_NO_PADDING);
 
     let walletPrivateKey: string | undefined = sodium.crypto_box_seal_open(binCipher, binPub, binPriv, "text");


### PR DESCRIPTION
At the moment permit2 payouts are broken. 

When issue is closed and permit2 URL is about to be generated the bot's config [here](https://github.com/ubiquity/ubiquibot/blob/development/src/utils/private.ts#L84) is an empty object because it is not yet initialized. 

That is why we read sodium's private key from the env variable instead of the bot's config.