### PR TITLE
fix: fix empty org desc

### DIFF
--- a/src/types/payload.ts
+++ b/src/types/payload.ts
@@ -200,7 +200,7 @@ const OrganizationSchema = Type.Object({
   members_url: Type.String(),
   public_members_url: Type.String(),
   avatar_url: Type.String(),
-  description: Type.String(),
+  description: Type.Union([Type.String(), Type.Null()]),
 });
 
 const InstallationSchema = Type.Object({


### PR DESCRIPTION
When the bot is added to a freshly created repository without a description there is the following error:
```
WARN [{"instancePath":"/organization/description","schemaPath":"#/properties/organization/properties/description/type","keyword":"type","params":{"type":"string"},"message":"must be string"}]
```

It happens because `organization.description` can be `null`. This PR makes `organization.description` to be `string` or `null`. 