### PR TITLE
Refactor/remove pk env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,4 @@ LOG_LEVEL=debug
 LOGDNA_INGESTION_KEY=
 
 # payout variables
-UBIQUITY_BOT_EVM_PRIVATE_KEY=""
 RPC_PROVIDER_URL="https://example.com/"

--- a/src/utils/private.ts
+++ b/src/utils/private.ts
@@ -124,9 +124,7 @@ export const getWideConfig = async (context: Context) => {
 
   const configData = {
     chainId: getChainId(parsedRepo, parsedOrg),
-    // TODO: remove "process.env.UBIQUITY_BOT_EVM_PRIVATE_KEY" when all partners are migrate to org wide config
-    privateKey: privateKeyDecrypted ?? process.env.UBIQUITY_BOT_EVM_PRIVATE_KEY ?? "",
-
+    privateKey: privateKeyDecrypted ?? "",
     baseMultiplier: getBaseMultiplier(parsedRepo, parsedOrg),
     timeLabels: getTimeLabels(parsedRepo, parsedOrg),
     priorityLabels: getPriorityLabels(parsedRepo, parsedOrg),


### PR DESCRIPTION
This PR removes the `UBIQUITY_BOT_EVM_PRIVATE_KEY` env variable. We no longer need it because we read partner wallet private keys from the bot config.