### PR TITLE
build: set payouts to gnosis chain

### DIFF
--- a/.github/ubiquibot-config.yml
+++ b/.github/ubiquibot-config.yml
@@ -1,4 +1,5 @@
 ---
+chain-id: 100
 base-multiplier: 1500
 time-labels:
   - name: "Time: <1 Hour"


### PR DESCRIPTION
This PR enables payouts for gnosis chain (i.e. all bounty hunters will start to receive rewards in gnosis chain's WXDAI)