### PR TITLE
fix: fix ERR_REQUIRE_ESM

### DIFF
--- a/src/helpers/comment.ts
+++ b/src/helpers/comment.ts
@@ -1,7 +1,3 @@
-import { fromMarkdown } from "mdast-util-from-markdown";
-import { gfmFromMarkdown } from "mdast-util-gfm";
-import { gfm } from "micromark-extension-gfm";
-
 type MdastNode = {
   type: string;
   value: string;
@@ -24,6 +20,10 @@ const traverse = (node: MdastNode, itemsToExclude: string[]): Record<string, str
 };
 
 export const parseComments = async (comments: string[], itemsToExclude: string[]): Promise<Record<string, string[]>> => {
+  const { fromMarkdown } = await import("mdast-util-from-markdown");
+  const { gfmFromMarkdown } = await import("mdast-util-gfm");
+  const { gfm } = await import("micromark-extension-gfm");
+
   const result: Record<string, string[]> = {};
   for (const comment of comments) {
     const tree = fromMarkdown(comment, {


### PR DESCRIPTION
This PR fixes this [error](https://github.com/ubiquity/ubiquibot/issues/290#issuecomment-1573450082)

The `mdast-util-from-markdown` is an ESM module. Our project setup does not support such modules (we support only commonjs modules). As soon as probot [moves to ESM](https://github.com/probot/probot/issues/1684) we can also [enable full ESM support](https://github.com/ubiquity/ubiquibot/issues/378) for our project.