### PR TITLE
feat: comment out payout command

### DIFF
--- a/src/handlers/comment/handlers/index.ts
+++ b/src/handlers/comment/handlers/index.ts
@@ -3,7 +3,6 @@ import { Payload, UserCommands } from "../../../types";
 import { IssueCommentCommands } from "../commands";
 import { assign } from "./assign";
 import { listAvailableCommands } from "./help";
-import { payout } from "./payout";
 import { unassign } from "./unassign";
 import { registerWallet } from "./wallet";
 import { setAccess } from "./set-access";
@@ -106,12 +105,12 @@ export const userCommands: UserCommands[] = [
     description: "List all available commands.",
     callback: commandCallback,
   },
-  {
+  /*{
     id: IssueCommentCommands.PAYOUT,
     description: "Disable automatic payment for the issue.",
     handler: payout,
     callback: commandCallback,
-  },
+  },*/
   {
     id: IssueCommentCommands.MULTIPLIER,
     description: `Set bounty multiplier (for treasury)`,

--- a/src/handlers/comment/handlers/index.ts
+++ b/src/handlers/comment/handlers/index.ts
@@ -3,6 +3,8 @@ import { Payload, UserCommands } from "../../../types";
 import { IssueCommentCommands } from "../commands";
 import { assign } from "./assign";
 import { listAvailableCommands } from "./help";
+// Commented out until Gnosis Safe is integrated (https://github.com/ubiquity/ubiquibot/issues/353)
+// import { payout } from "./payout";
 import { unassign } from "./unassign";
 import { registerWallet } from "./wallet";
 import { setAccess } from "./set-access";
@@ -105,6 +107,7 @@ export const userCommands: UserCommands[] = [
     description: "List all available commands.",
     callback: commandCallback,
   },
+  // Commented out until Gnosis Safe is integrated (https://github.com/ubiquity/ubiquibot/issues/353)
   /*{
     id: IssueCommentCommands.PAYOUT,
     description: "Disable automatic payment for the issue.",


### PR DESCRIPTION
resolves #353

I commented out the payout command in the user command list which also removes it from the help menu. 
I didn't remove the actual implementation of the command since it will be enabled once Gnosis Safe is supported