### PR TITLE
feat: added time config for max issue

### DIFF
--- a/src/configs/shared.ts
+++ b/src/configs/shared.ts
@@ -5,7 +5,8 @@ export const COLORS = {
   price: "1f883d",
 };
 export const DEFAULT_BOT_DELAY = 100; // 100ms
-
+export const TIME_RANGE_FOR_MAX_ISSUE = 24;
+export const TIME_RANGE_FOR_MAX_ISSUE_ENABLED = true;
 /**
  * ms('2 days')  // 172800000
  * ms('1d')      // 86400000

--- a/src/configs/shared.ts
+++ b/src/configs/shared.ts
@@ -5,8 +5,8 @@ export const COLORS = {
   price: "1f883d",
 };
 export const DEFAULT_BOT_DELAY = 100; // 100ms
-export const TIME_RANGE_FOR_MAX_ISSUE = 24;
-export const TIME_RANGE_FOR_MAX_ISSUE_ENABLED = true;
+export const DEFAULT_TIME_RANGE_FOR_MAX_ISSUE = 24;
+export const DEFAULT_TIME_RANGE_FOR_MAX_ISSUE_ENABLED = false;
 /**
  * ms('2 days')  // 172800000
  * ms('1d')      // 86400000

--- a/src/configs/shared.ts
+++ b/src/configs/shared.ts
@@ -6,7 +6,7 @@ export const COLORS = {
 };
 export const DEFAULT_BOT_DELAY = 100; // 100ms
 export const DEFAULT_TIME_RANGE_FOR_MAX_ISSUE = 24;
-export const DEFAULT_TIME_RANGE_FOR_MAX_ISSUE_ENABLED = false;
+export const DEFAULT_TIME_RANGE_FOR_MAX_ISSUE_ENABLED = true;
 /**
  * ms('2 days')  // 172800000
  * ms('1d')      // 86400000

--- a/src/handlers/comment/handlers/assign.ts
+++ b/src/handlers/comment/handlers/assign.ts
@@ -1,10 +1,4 @@
-import {
-  addAssignees,
-  addCommentToIssue,
-  getAssignedIssues,
-  getCommentsOfIssue,
-  getOpenedPullRequestWithNoReviewsOver24HoursPassedAfterCreated,
-} from "../../../helpers";
+import { addAssignees, addCommentToIssue, getAssignedIssues, getCommentsOfIssue, getAvailableOpenedPullRequests } from "../../../helpers";
 import { getBotConfig, getBotContext, getLogger } from "../../../bindings";
 import { Payload, LabelItem, Comment, IssueType } from "../../../types";
 import { deadLinePrefix } from "../../shared";
@@ -28,7 +22,7 @@ export const assign = async (body: string) => {
     return;
   }
 
-  const opened_prs = await getOpenedPullRequestWithNoReviewsOver24HoursPassedAfterCreated(payload.sender.login);
+  const opened_prs = await getAvailableOpenedPullRequests(payload.sender.login);
 
   logger.info(`Opened Pull Requests with no reviews but over 24 hours have passed: ${JSON.stringify(opened_prs)}`);
 

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -344,11 +344,13 @@ export const getOpenedPullRequests = async (username: string) => {
   return prs.filter((pr) => !pr.draft && pr.user?.login === username);
 };
 
-export const getOpenedPullRequestWithNoReviewsOver24HoursPassedAfterCreated = async (username: string) => {
+export const getAvailableOpenedPullRequests = async (username: string) => {
   if (!DEFAULT_TIME_RANGE_FOR_MAX_ISSUE_ENABLED) return [];
   const context = getBotContext();
   const opened_prs = await getOpenedPullRequests(username);
+
   const result = [];
+
   for (let i = 0; i < opened_prs.length; i++) {
     const pr = opened_prs[i];
     const reviews = await getAllPullRequestReviews(context, pr.number);

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -352,7 +352,9 @@ export const getOpenedPullRequestWithNoReviewsOver24HoursPassedAfterCreated = as
   for (let i = 0; i < opened_prs.length; i++) {
     const pr = opened_prs[i];
     const reviews = await getAllPullRequestReviews(context, pr.number);
+
     if (reviews.length > 0) result.push(pr);
+
     if (reviews.length === 0 && (new Date().getTime() - new Date(pr.created_at).getTime()) / (1000 * 60 * 60) >= DEFAULT_TIME_RANGE_FOR_MAX_ISSUE) {
       result.push(pr);
     }

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -2,6 +2,7 @@ import { Context } from "probot";
 import { getBotContext, getLogger } from "../bindings";
 import { Comment, IssueType, Payload } from "../types";
 import { checkRateLimitGit } from "../utils";
+import { TIME_RANGE_FOR_MAX_ISSUE, TIME_RANGE_FOR_MAX_ISSUE_ENABLED } from "../configs";
 
 export const clearAllPriceLabelsOnIssue = async (): Promise<void> => {
   const context = getBotContext();
@@ -338,6 +339,7 @@ export const getAssignedIssues = async (username: string) => {
 };
 
 export const getOpenedPullRequestWithNoReviewsOver24HoursPassedAfterCreated = async (username: string) => {
+  if (!TIME_RANGE_FOR_MAX_ISSUE_ENABLED) return [];
   const context = getBotContext();
   const prs = await getPullRequests(context, "open");
   const opened_prs = [];
@@ -346,7 +348,10 @@ export const getOpenedPullRequestWithNoReviewsOver24HoursPassedAfterCreated = as
     if (pr.draft) continue;
     if (pr.user?.login !== username) continue;
     const reviews = await getAllPullRequestReviews(context, pr.number);
-    if (reviews.length > 0 || (reviews.length === 0 && (new Date().getTime() - new Date(pr.created_at).getTime()) / (1000 * 60 * 60) >= 24)) {
+    if (
+      reviews.length > 0 ||
+      (reviews.length === 0 && (new Date().getTime() - new Date(pr.created_at).getTime()) / (1000 * 60 * 60) >= TIME_RANGE_FOR_MAX_ISSUE)
+    ) {
       opened_prs.push(pr);
     }
   }

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -2,7 +2,7 @@ import { Context } from "probot";
 import { getBotContext, getLogger } from "../bindings";
 import { Comment, IssueType, Payload } from "../types";
 import { checkRateLimitGit } from "../utils";
-import { TIME_RANGE_FOR_MAX_ISSUE, TIME_RANGE_FOR_MAX_ISSUE_ENABLED } from "../configs";
+import { DEFAULT_TIME_RANGE_FOR_MAX_ISSUE, DEFAULT_TIME_RANGE_FOR_MAX_ISSUE_ENABLED } from "../configs";
 
 export const clearAllPriceLabelsOnIssue = async (): Promise<void> => {
   const context = getBotContext();
@@ -338,22 +338,24 @@ export const getAssignedIssues = async (username: string) => {
   return assigned_issues;
 };
 
-export const getOpenedPullRequestWithNoReviewsOver24HoursPassedAfterCreated = async (username: string) => {
-  if (!TIME_RANGE_FOR_MAX_ISSUE_ENABLED) return [];
+export const getOpenedPullRequests = async (username: string) => {
   const context = getBotContext();
   const prs = await getPullRequests(context, "open");
-  const opened_prs = [];
-  for (let i = 0; i < prs.length; i++) {
-    const pr = prs[i];
-    if (pr.draft) continue;
-    if (pr.user?.login !== username) continue;
+  return prs.filter((pr) => !pr.draft && pr.user?.login === username);
+};
+
+export const getOpenedPullRequestWithNoReviewsOver24HoursPassedAfterCreated = async (username: string) => {
+  if (!DEFAULT_TIME_RANGE_FOR_MAX_ISSUE_ENABLED) return [];
+  const context = getBotContext();
+  const opened_prs = await getOpenedPullRequests(username);
+  const result = [];
+  for (let i = 0; i < opened_prs.length; i++) {
+    const pr = opened_prs[i];
     const reviews = await getAllPullRequestReviews(context, pr.number);
-    if (
-      reviews.length > 0 ||
-      (reviews.length === 0 && (new Date().getTime() - new Date(pr.created_at).getTime()) / (1000 * 60 * 60) >= TIME_RANGE_FOR_MAX_ISSUE)
-    ) {
-      opened_prs.push(pr);
+    if (reviews.length > 0) result.push(pr);
+    if (reviews.length === 0 && (new Date().getTime() - new Date(pr.created_at).getTime()) / (1000 * 60 * 60) >= DEFAULT_TIME_RANGE_FOR_MAX_ISSUE) {
+      result.push(pr);
     }
   }
-  return opened_prs;
+  return result;
 };


### PR DESCRIPTION
Resolves #388 
Test successful.
You can see the test result at https://github.com/wannacfuture/Battleship/issues/19
There, I can't assign to that issue even I have one pull request which is created over 24 hours before, because TIME_RANGE_FOR_MAX_ISSUE_ENABLED was set `false` so bot doesn't count PRs.
Also I added TIME_RANGE_FOR_MAX_ISSUE for flexible time configuration for max-bounty-issue.
