### PR TITLE
feat: close prs when unassigned

### DIFF
--- a/src/handlers/assign/action.ts
+++ b/src/handlers/assign/action.ts
@@ -62,7 +62,7 @@ export const commentWithAssignMessage = async (): Promise<void> => {
   await addCommentToIssue(commit_msg, payload.issue!.number);
 };
 
-export const closePullRequestOfTheIssue = async (): Promise<void> => {
+export const closePullRequestForAnIssue = async (): Promise<void> => {
   const context = getBotContext();
   // const config = getBotConfig();
   const logger = getLogger();

--- a/src/handlers/assign/action.ts
+++ b/src/handlers/assign/action.ts
@@ -1,5 +1,5 @@
 import { getBotConfig, getBotContext, getLogger } from "../../bindings";
-import { addCommentToIssue } from "../../helpers";
+import { addCommentToIssue, closePullRequest, getOpenedPullRequestsForAnIssue } from "../../helpers";
 import { Payload, LabelItem } from "../../types";
 import { deadLinePrefix } from "../shared";
 
@@ -60,4 +60,20 @@ export const commentWithAssignMessage = async (): Promise<void> => {
   logger.debug(`Creating an issue comment, commit_msg: ${commit_msg}`);
 
   await addCommentToIssue(commit_msg, payload.issue!.number);
+};
+
+export const closePullRequestOfTheIssue = async (): Promise<void> => {
+  const context = getBotContext();
+  // const config = getBotConfig();
+  const logger = getLogger();
+
+  const payload = context.payload as Payload;
+  const prs = await getOpenedPullRequestsForAnIssue(payload.issue?.number!, payload.sender.login);
+  logger.info(`Opened prs for this issue: ${JSON.stringify(prs)}`);
+  let comment = `These linked pull requests are closed: `;
+  for (let i = 0; i < prs.length; i++) {
+    await closePullRequest(prs[i].number);
+    comment += ` <a href="${prs[i]._links.html.href}">#${prs[i].number}</a> `;
+  }
+  await addCommentToIssue(comment, payload.issue?.number!);
 };

--- a/src/handlers/comment/handlers/unassign.ts
+++ b/src/handlers/comment/handlers/unassign.ts
@@ -2,6 +2,7 @@ import { removeAssignees } from "../../../helpers";
 import { getBotContext, getLogger } from "../../../bindings";
 import { Payload } from "../../../types";
 import { IssueCommentCommands } from "../commands";
+import { closePullRequestOfTheIssue } from "../../assign/action";
 
 export const unassign = async (body: string) => {
   const { payload: _payload } = getBotContext();
@@ -27,6 +28,7 @@ export const unassign = async (body: string) => {
   logger.debug(`Unassigning sender: ${payload.sender.login.toLowerCase()}, assignee: ${assignees[0].login.toLowerCase()}, shouldUnassign: ${shouldUnassign}`);
 
   if (shouldUnassign) {
+    await closePullRequestOfTheIssue();
     await removeAssignees(
       issue_number,
       assignees.map((i) => i.login)

--- a/src/handlers/comment/handlers/unassign.ts
+++ b/src/handlers/comment/handlers/unassign.ts
@@ -2,7 +2,7 @@ import { removeAssignees } from "../../../helpers";
 import { getBotContext, getLogger } from "../../../bindings";
 import { Payload } from "../../../types";
 import { IssueCommentCommands } from "../commands";
-import { closePullRequestOfTheIssue } from "../../assign/action";
+import { closePullRequestForAnIssue } from "../../assign/action";
 
 export const unassign = async (body: string) => {
   const { payload: _payload } = getBotContext();
@@ -28,7 +28,7 @@ export const unassign = async (body: string) => {
   logger.debug(`Unassigning sender: ${payload.sender.login.toLowerCase()}, assignee: ${assignees[0].login.toLowerCase()}, shouldUnassign: ${shouldUnassign}`);
 
   if (shouldUnassign) {
-    await closePullRequestOfTheIssue();
+    await closePullRequestForAnIssue();
     await removeAssignees(
       issue_number,
       assignees.map((i) => i.login)

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -356,12 +356,15 @@ export const getAssignedIssues = async (username: string) => {
 
 export const getOpenedPullRequestsForAnIssue = async (issueNumber: number, userName: string) => {
   const pulls = await getOpenedPullRequests(userName);
+
   return pulls.filter((pull) => {
     if (pull.draft) return false;
+
     const issues = pull.body!.match(/#(\d+)/gi);
+
     if (!issues) return false;
+
     const linkedIssueNumbers = Array.from(new Set(issues.map((issue) => issue.replace("#", ""))));
-    console.log(linkedIssueNumbers);
     if (linkedIssueNumbers.indexOf(`${issueNumber}`) !== -1) return true;
     return false;
   });

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -358,8 +358,6 @@ export const getOpenedPullRequestsForAnIssue = async (issueNumber: number, userN
   const pulls = await getOpenedPullRequests(userName);
 
   return pulls.filter((pull) => {
-    if (pull.draft) return false;
-
     const issues = pull.body!.match(/#(\d+)/gi);
 
     if (!issues) return false;


### PR DESCRIPTION
Resolves #379 
Test successful! 
You can see the result on https://github.com/wannacfuture/Battleship/issues/23
There, when the user unassign, the linked pull requests of him are closed and the comment is added.
