### PR TITLE
feat: rename chainId to network in permit URL

### DIFF
--- a/src/helpers/permit.ts
+++ b/src/helpers/permit.ts
@@ -57,7 +57,7 @@ export const generatePermit2Signature = async (spender: string, amountInEth: str
 
   const base64encodedTxData = Buffer.from(JSON.stringify(txData)).toString("base64");
 
-  const result = `${permitBaseUrl}?claim=${base64encodedTxData}&chainId=0x${chainId.toString(16)}`;
+  const result = `${permitBaseUrl}?claim=${base64encodedTxData}&network=0x${chainId.toString(16)}`;
   logger.info(`Generated permit2 url: ${result}`);
   return result;
 };


### PR DESCRIPTION
https://pay.ubq.fi/ now [handles](https://github.com/ubiquity/pay.ubq.fi/pull/88) the `network` URL query parameter instead of the `chainId` param