### PR TITLE
feat: disallow assigning on non new pulls

### DIFF
--- a/src/handlers/assign/auto.ts
+++ b/src/handlers/assign/auto.ts
@@ -1,5 +1,5 @@
 import { getBotContext, getLogger } from "../../bindings";
-import { addAssignees, getIssueByNumber, getPullRequests } from "../../helpers";
+import { addAssignees, getIssueByNumber, getPullByNumber, getPullRequests } from "../../helpers";
 import { gitLinkedIssueParser } from "../../helpers/parser";
 import { Payload } from "../../types";
 
@@ -26,6 +26,14 @@ export const checkPullRequests = async () => {
 
     // if pullRequestLinked is empty, continue
     if (pullRequestLinked == "" || !pull.user) {
+      continue;
+    }
+
+    const connectedPull = await getPullByNumber(context, pull.number);
+
+    // Newly created PULL (draft or direct) pull does have same `created_at` and `updated_at`.
+    if (connectedPull?.created_at !== connectedPull?.updated_at) {
+      logger.debug("It's an updated Pull Request, reverting");
       continue;
     }
 

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -344,6 +344,18 @@ export const getIssueByNumber = async (context: Context, issue_number: number) =
   }
 };
 
+export const getPullByNumber = async (context: Context, pull_number: number) => {
+  const logger = getLogger();
+  const payload = context.payload as Payload;
+  try {
+    const { data: pull } = await context.octokit.rest.pulls.get({ owner: payload.repository.owner.login, repo: payload.repository.name, pull_number });
+    return pull;
+  } catch (error) {
+    logger.debug(`Fetching pull failed!, reason: ${error}`);
+    return;
+  }
+};
+
 // Get issues assigned to a username
 export const getAssignedIssues = async (username: string) => {
   const issuesArr = [];


### PR DESCRIPTION
Resolves #491 

If a new pull request is created `created_at` and `updated_at` both does possess same values based on that this PR resolves the linked issue.

<!--
- You must link the issue number e.g. "Resolves #1234"
- You must link the QA issue on your forked repo e.g. "QA for #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
