### PR TITLE
feat: prevent double comment by the bot

### DIFF
--- a/src/handlers/comment/action.ts
+++ b/src/handlers/comment/action.ts
@@ -37,13 +37,13 @@ export const handleComment = async (): Promise<void> => {
       try {
         const response = await handler(body);
         const callbackComment = response ?? successComment ?? "";
-        if (callbackComment) await callback(issue.number, callbackComment);
+        if (callbackComment) await callback(payload, callbackComment);
       } catch (err: unknown) {
         // Use failureComment for failed command if it is available
         if (failureComment) {
-          await callback(issue.number, failureComment);
+          await callback(payload, failureComment);
         }
-        await callback(issue.number, `Error: ${err}`);
+        await callback(payload, `Error: ${err}`);
       }
     } else {
       logger.info(`Skipping for a command: ${command}`);

--- a/src/handlers/comment/action.ts
+++ b/src/handlers/comment/action.ts
@@ -37,13 +37,13 @@ export const handleComment = async (): Promise<void> => {
       try {
         const response = await handler(body);
         const callbackComment = response ?? successComment ?? "";
-        if (callbackComment) await callback(payload, callbackComment);
+        if (callbackComment) await callback(issue.number, callbackComment, payload.action, payload.comment);
       } catch (err: unknown) {
         // Use failureComment for failed command if it is available
         if (failureComment) {
-          await callback(payload, failureComment);
+          await callback(issue.number, failureComment, payload.action, payload.comment);
         }
-        await callback(payload, `Error: ${err}`);
+        await callback(issue.number, `Error: ${err}`, payload.action, payload.comment);
       }
     } else {
       logger.info(`Skipping for a command: ${command}`);

--- a/src/handlers/comment/handlers/first.ts
+++ b/src/handlers/comment/handlers/first.ts
@@ -1,6 +1,6 @@
 import { getBotContext, getLogger } from "../../../bindings";
 import { COMMAND_INSTRUCTIONS } from "../../../configs";
-import { addCommentToIssue } from "../../../helpers";
+import { upsertCommentToIssue } from "../../../helpers";
 import { Payload } from "../../../types";
 
 export const verifyFirstCheck = async (): Promise<void> => {
@@ -26,7 +26,7 @@ export const verifyFirstCheck = async (): Promise<void> => {
       if (isFirstComment) {
         //first_comment
         const msg = `${COMMAND_INSTRUCTIONS}\n@${payload.sender.login}`;
-        await addCommentToIssue(msg, payload.issue.number);
+        await upsertCommentToIssue(payload.issue.number, msg, payload.action, payload.comment);
       }
     }
   } catch (error: unknown) {

--- a/src/handlers/comment/handlers/index.ts
+++ b/src/handlers/comment/handlers/index.ts
@@ -9,7 +9,7 @@ import { unassign } from "./unassign";
 import { registerWallet } from "./wallet";
 import { setAccess } from "./set-access";
 import { multiplier } from "./multiplier";
-import { addCommentToIssue, createLabel, addLabelToIssue } from "../../../helpers";
+import { addCommentToIssue, createLabel, addLabelToIssue, updateCommentOfIssue } from "../../../helpers";
 import { getBotContext } from "../../../bindings";
 import { handleIssueClosed } from "../../payout";
 
@@ -90,7 +90,11 @@ export const issueCreatedCallback = async (): Promise<void> => {
  */
 const commandCallback = async (payload: Payload, comment: string) => {
   if (payload.issue?.number) {
-    await addCommentToIssue(comment, payload.issue?.number);
+    if (payload.action == "edited") {
+      await updateCommentOfIssue(comment, payload);
+    } else {
+      await addCommentToIssue(comment, payload.issue?.number);
+    }
   }
 };
 

--- a/src/handlers/comment/handlers/index.ts
+++ b/src/handlers/comment/handlers/index.ts
@@ -9,7 +9,7 @@ import { unassign } from "./unassign";
 import { registerWallet } from "./wallet";
 import { setAccess } from "./set-access";
 import { multiplier } from "./multiplier";
-import { addCommentToIssue, createLabel, addLabelToIssue, updateCommentOfIssue } from "../../../helpers";
+import { addCommentToIssue, createLabel, addLabelToIssue, upsertCommentToIssue } from "../../../helpers";
 import { getBotContext } from "../../../bindings";
 import { handleIssueClosed } from "../../payout";
 
@@ -90,11 +90,7 @@ export const issueCreatedCallback = async (): Promise<void> => {
  */
 
 const commandCallback = async (issue_number: number, comment: string, action: string, reply_to?: Comment) => {
-  if (action == "edited" && reply_to) {
-    await updateCommentOfIssue(comment, issue_number, reply_to);
-  } else {
-    await addCommentToIssue(comment, issue_number);
-  }
+  await upsertCommentToIssue(issue_number, comment, action, reply_to);
 };
 
 export const userCommands: UserCommands[] = [

--- a/src/handlers/comment/handlers/index.ts
+++ b/src/handlers/comment/handlers/index.ts
@@ -1,5 +1,5 @@
 import { getBotConfig } from "../../../bindings";
-import { Payload, UserCommands } from "../../../types";
+import { Comment, Payload, UserCommands } from "../../../types";
 import { IssueCommentCommands } from "../commands";
 import { assign } from "./assign";
 import { listAvailableCommands } from "./help";
@@ -88,13 +88,12 @@ export const issueCreatedCallback = async (): Promise<void> => {
  * @param issue_number - The issue number
  * @param comment - Comment string
  */
-const commandCallback = async (payload: Payload, comment: string) => {
-  if (payload.issue?.number) {
-    if (payload.action == "edited") {
-      await updateCommentOfIssue(comment, payload);
-    } else {
-      await addCommentToIssue(comment, payload.issue?.number);
-    }
+
+const commandCallback = async (issue_number: number, comment: string, action: string, reply_to?: Comment) => {
+  if (action == "edited" && reply_to) {
+    await updateCommentOfIssue(comment, issue_number, reply_to);
+  } else {
+    await addCommentToIssue(comment, issue_number);
   }
 };
 

--- a/src/handlers/comment/handlers/index.ts
+++ b/src/handlers/comment/handlers/index.ts
@@ -88,8 +88,10 @@ export const issueCreatedCallback = async (): Promise<void> => {
  * @param issue_number - The issue number
  * @param comment - Comment string
  */
-const commandCallback = async (issue_number: number, comment: string) => {
-  await addCommentToIssue(comment, issue_number);
+const commandCallback = async (payload: Payload, comment: string) => {
+  if (payload.issue?.number) {
+    await addCommentToIssue(comment, payload.issue?.number);
+  }
 };
 
 export const userCommands: UserCommands[] = [

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -126,6 +126,14 @@ export const updateCommentOfIssue = async (msg: string, issue_number: number, re
   }
 };
 
+export const upsertCommentToIssue = async (issue_number: number, comment: string, action: string, reply_to?: Comment) => {
+  if (action == "edited" && reply_to) {
+    await updateCommentOfIssue(comment, issue_number, reply_to);
+  } else {
+    await addCommentToIssue(comment, issue_number);
+  }
+};
+
 export const getCommentsOfIssue = async (issue_number: number): Promise<Comment[]> => {
   const context = getBotContext();
   const logger = getLogger();

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -84,46 +84,45 @@ export const addCommentToIssue = async (msg: string, issue_number: number) => {
   }
 };
 
-export const updateCommentOfIssue = async (msg: string, payload: Payload) => {
+export const updateCommentOfIssue = async (msg: string, issue_number: number, reply_to: Comment) => {
   const context = getBotContext();
   const logger = getLogger();
+  const payload = context.payload as Payload;
 
-  if (payload.issue) {
-    try {
-      const appResponse = await context.octokit.apps.getAuthenticated();
-      const { name, slug } = appResponse.data;
-      logger.info(`App name/slug ${name}/${slug}`);
+  try {
+    const appResponse = await context.octokit.apps.getAuthenticated();
+    const { name, slug } = appResponse.data;
+    logger.info(`App name/slug ${name}/${slug}`);
 
-      const editCommentBy = `${slug}[bot]`;
-      logger.info(`Bot slug: ${editCommentBy}`);
+    const editCommentBy = `${slug}[bot]`;
+    logger.info(`Bot slug: ${editCommentBy}`);
 
-      const comments = await context.octokit.issues.listComments({
+    const comments = await context.octokit.issues.listComments({
+      owner: payload.repository.owner.login,
+      repo: payload.repository.name,
+      issue_number: issue_number,
+      since: reply_to.created_at,
+      per_page: 30,
+    });
+
+    const comment_to_edit = comments.data.find((comment) => {
+      return comment?.user?.login == editCommentBy && comment.id > reply_to.id;
+    });
+
+    if (comment_to_edit) {
+      logger.info(`For comment_id: ${reply_to.id} found comment_to_edit with id: ${comment_to_edit.id}`);
+      await context.octokit.issues.updateComment({
         owner: payload.repository.owner.login,
         repo: payload.repository.name,
-        issue_number: payload.issue.number,
-        since: payload.comment?.created_at,
-        per_page: 30,
+        comment_id: comment_to_edit.id,
+        body: msg,
       });
-
-      const comment_to_edit = comments.data.find((comment) => {
-        return comment?.user?.login == editCommentBy && payload.comment?.id && comment.id > payload.comment?.id;
-      });
-
-      if (comment_to_edit) {
-        logger.info(`For comment_id: ${payload.comment?.id} found comment_to_edit with id: ${comment_to_edit.id}`);
-        await context.octokit.issues.updateComment({
-          owner: payload.repository.owner.login,
-          repo: payload.repository.name,
-          comment_id: comment_to_edit.id,
-          body: msg,
-        });
-      } else {
-        logger.info(`Fallingback to add comment. Couldn't find response to edit for comment_id: ${payload.comment?.id}`);
-        await addCommentToIssue(msg, payload.issue.number);
-      }
-    } catch (e: unknown) {
-      logger.debug(`Upading a comment failed!, reason: ${e}`);
+    } else {
+      logger.info(`Falling back to add comment. Couldn't find response to edit for comment_id: ${reply_to.id}`);
+      await addCommentToIssue(msg, issue_number);
     }
+  } catch (e: unknown) {
+    logger.debug(`Upading a comment failed!, reason: ${e}`);
   }
 };
 

--- a/src/types/handlers.ts
+++ b/src/types/handlers.ts
@@ -1,8 +1,8 @@
-import { Payload } from "./payload";
+import { Comment } from "./payload";
 
 export type CommandsHandler = (args: string) => Promise<string | undefined>;
 export type ActionHandler = (args?: string) => Promise<void>;
-export type CallbackHandler = (payload: Payload, text: string) => Promise<void>;
+export type CallbackHandler = (issue_number: number, text: string, action: string, reply_to?: Comment) => Promise<void>;
 export type PreActionHandler = ActionHandler;
 export type PostActionHandler = ActionHandler;
 

--- a/src/types/handlers.ts
+++ b/src/types/handlers.ts
@@ -1,6 +1,8 @@
+import { Payload } from "./payload";
+
 export type CommandsHandler = (args: string) => Promise<string | undefined>;
 export type ActionHandler = (args?: string) => Promise<void>;
-export type CallbackHandler = (issue_number: number, text: string) => Promise<void>;
+export type CallbackHandler = (payload: Payload, text: string) => Promise<void>;
 export type PreActionHandler = ActionHandler;
 export type PostActionHandler = ActionHandler;
 


### PR DESCRIPTION
Resolves #440
QA https://github.com/web4er/ubiquibot/issues/35

A question that may arise: why were `payload.comment`, `payload.action` passed through argument and not used directly from the context? This is possible for all commands except `assign`.  Assign changes the context before the comment happens. `payload.comment` is undefined for assign in the addComment and we need the comment to find information about the comment and its response to edit. That is why, they are passing it through the argument. 
<!--
- You must link the issue number e.g. "Resolves #1234"
- You must link the QA issue on your forked repo e.g. "QA for #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
