### PR TITLE
build: rename `base-multiplier` to `price-multiplier`

### DIFF
--- a/.github/ubiquibot-config.yml
+++ b/.github/ubiquibot-config.yml
@@ -1,6 +1,6 @@
 ---
 evm-network-id: 100
-base-multiplier: 1500
+price-multiplier: 1.5
 time-labels:
   - name: "Time: <1 Hour"
     weight: 0.125


### PR DESCRIPTION
This PR renames bot's config param (introduced [here](https://github.com/ubiquity/ubiquibot/pull/555)) `base-multiplier` to `price-multiplier` along with updating it's value to be a single integer

The current PR should be merged when:
1. This [PR](https://github.com/ubiquity/ubiquibot/pull/555) is merged
2. A new bot's production version is released with this [PR](https://github.com/ubiquity/ubiquibot/pull/555) included
