### PR TITLE
Edit instead of double post (initial pull request)

### DIFF
--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -598,6 +598,6 @@ export const getAvailableOpenedPullRequests = async (username: string) => {
 export const checkIfLastCommentIsBot = async (issue_number: number) => {
   const comments = await getAllIssueComments(issue_number);
   const lastComment = comments.pop();
-  if(!lastComment) return false;
-  return lastComment.user.type === UserType.Bot
+  if (!lastComment) return false;
+  return lastComment.user.type === UserType.Bot;
 };


### PR DESCRIPTION
Resolves #601 
QA (I am not sure how I can make the bot 'double post')
I basically implemented logic for "edit instead of double post".
The logic is to check if last comment is bot and if so just update comment instead of adding.
![image](https://github.com/ubiquity/ubiquibot/assets/103924884/75198eb3-f385-49d0-ac7e-3d23c6770369)


<!--
- You must link the issue number e.g. "Resolves #1234"
- You must link the QA issue on your forked repo e.g. "QA for #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
