### PR TITLE
feat: extract duration dynamically from time label name

### DIFF
--- a/.github/ubiquibot-config.yml
+++ b/.github/ubiquibot-config.yml
@@ -3,19 +3,14 @@ price-multiplier: 1.5
 time-labels:
   - name: "Time: <1 Hour"
     weight: 0.125
-    value: 3600
   - name: "Time: <2 Hours"
     weight: 0.25
-    value: 7200
   - name: "Time: <4 Hours"
     weight: 0.5
-    value: 14400
   - name: "Time: <1 Day"
     weight: 1
-    value: 86400
   - name: "Time: <1 Week"
     weight: 2
-    value: 604800
 priority-labels:
   - name: "Priority: 0 (Normal)"
     weight: 1

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@supabase/supabase-js": "^2.4.0",
     "@types/mdast": "^3.0.11",
     "@types/ms": "^0.7.31",
+    "@types/timestring": "^6.0.2",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.11",
     "@uniswap/permit2-sdk": "^1.2.0",
@@ -61,6 +62,7 @@
     "prettier": "^2.7.1",
     "probot": "^12.2.4",
     "telegraf": "^4.11.2",
+    "timestring": "^7.0.0",
     "tsx": "^3.12.7",
     "yaml": "^2.2.2"
   },

--- a/src/handlers/assign/action.ts
+++ b/src/handlers/assign/action.ts
@@ -1,3 +1,5 @@
+import timestring from "timestring";
+
 import { getBotConfig, getBotContext, getLogger } from "../../bindings";
 import { addCommentToIssue, closePullRequest, getOpenedPullRequestsForAnIssue } from "../../helpers";
 import { Payload, LabelItem } from "../../types";
@@ -51,7 +53,7 @@ export const commentWithAssignMessage = async (): Promise<void> => {
 
   const sorted = timeLabelsAssigned.sort((a, b) => a.weight - b.weight);
   const targetTimeLabel = sorted[0];
-  const duration = targetTimeLabel.value;
+  const duration = timestring(targetTimeLabel.name);
   if (!duration) {
     logger.debug(`Missing configure for timelabel: ${targetTimeLabel.name}`);
     return;

--- a/src/handlers/comment/handlers/assign.ts
+++ b/src/handlers/comment/handlers/assign.ts
@@ -1,3 +1,5 @@
+import timestring from "timestring";
+
 import { addAssignees, getAssignedIssues, getAvailableOpenedPullRequests, getAllIssueComments } from "../../../helpers";
 import { getBotConfig, getBotContext, getLogger } from "../../../bindings";
 import { Payload, LabelItem, Comment, IssueType, Issue } from "../../../types";
@@ -83,7 +85,7 @@ export const assign = async (body: string) => {
 
   const sorted = timeLabelsAssigned.sort((a, b) => a.weight - b.weight);
   const targetTimeLabel = sorted[0];
-  const duration = targetTimeLabel.value;
+  const duration = timestring(targetTimeLabel.name);
   if (!duration) {
     logger.info(`Missing configure for time label: ${targetTimeLabel.name}`);
     return "Skipping `/start` since configuration is missing for the following labels";

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,7 +3,6 @@ import { Static, Type } from "@sinclair/typebox";
 const LabelItemSchema = Type.Object({
   name: Type.String(),
   weight: Type.Number(),
-  value: Type.Optional(Type.Number()),
 });
 export type LabelItem = Static<typeof LabelItemSchema>;
 


### PR DESCRIPTION
Resolves #431 

QA: https://github.com/wannacfuture/Battleship/issues/85


Used `timestring` library due to `ms` doesn't support months and years