### PR TITLE
feat: toggle permit generation by external

### DIFF
--- a/src/handlers/payout/action.ts
+++ b/src/handlers/payout/action.ts
@@ -25,6 +25,7 @@ export const handleIssueClosed = async () => {
   const {
     payout: { paymentToken, rpc, permitBaseUrl, networkId, privateKey },
     mode: { paymentPermitMaxPrice },
+    accessControl,
   } = getBotConfig();
   const logger = getLogger();
   const payload = context.payload as Payload;
@@ -35,9 +36,11 @@ export const handleIssueClosed = async () => {
 
   if (!issue) return;
 
-  const userHasPermission = await checkUserPermissionForRepoAndOrg(payload.sender.login, context);
+  if (accessControl.organization) {
+    const userHasPermission = await checkUserPermissionForRepoAndOrg(payload.sender.login, context);
 
-  if (!userHasPermission) return "Permit generation skipped because this issue has been closed by an external contributor.";
+    if (!userHasPermission) return "Permit generation skipped because this issue has been closed by an external contributor.";
+  }
 
   const comments = await getAllIssueComments(issue.number);
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -95,6 +95,7 @@ export const WalletSchema = Type.Object({
 
 export const AccessControlSchema = Type.Object({
   label: Type.Boolean(),
+  organization: Type.Boolean(),
 });
 
 export type AccessControl = Static<typeof AccessControlSchema>;

--- a/ubiquibot-config-default.json
+++ b/ubiquibot-config-default.json
@@ -87,6 +87,7 @@
     }
   },
   "enable-access-control": {
-    "label": false
+    "label": false,
+    "organization": true
   }
 }


### PR DESCRIPTION
> another thing discussed with pavlovcik in DM
> 
> check this comment https://github.com/ubiquity/ubiquibar/issues/13#issuecomment-1701225272
> 
> When issue is closed by an outside collaborator then the permit generation is skipped
> 
> When https://github.com/ubiquity/ubiquibot/pull/696/ is reviewed and merged I will add a new bot config param enable-access-control.organization that enables/disables this [check](https://github.com/rndquu/bounty-bot/blob/d0a7f796114bea474f26a1eeb003d72c6d61cd78/src/handlers/payout/action.ts#L38)
> 
> So we could enable this new param for all of our organizations but disable for certain repos temporary
> https://t.me/c/1588400061/1/4590

QA: For external user `enable-access-control.organization=false`  https://github.com/web4erOrg/web4er-sandbox/issues/11
QA: For external user `enable-access-control.organization=true`  https://github.com/web4erOrg/web4er-sandbox/issues/15 (strangely still creates permit for task creator but I think not issue of concern at the moment)

QA: For internal user `enable-access-control.organization=false` https://github.com/web4erOrg/web4er-sandbox/issues/12
QA: For internal user `enable-access-control.organization=true` https://github.com/web4erOrg/web4er-sandbox/issues/14

<!--
- You must link the issue number e.g. "Resolves #1234"
- You must link the QA issue on your forked repo e.g. "QA for #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
