### PR TITLE
fix: enable assistive pricing when label access control is false

### DIFF
--- a/src/handlers/access/labels-access.ts
+++ b/src/handlers/access/labels-access.ts
@@ -5,7 +5,7 @@ import { Payload } from "../../types";
 
 export const handleLabelsAccess = async () => {
   const { accessControl } = getBotConfig();
-  if (!accessControl.label) return;
+  if (!accessControl.label) return true;
 
   const context = getBotContext();
   const logger = getLogger();


### PR DESCRIPTION
This PR enables assistive pricing when `enable-access-control.label = false`