### PR TITLE
feat: support minute labels

### DIFF
--- a/src/helpers/shared.ts
+++ b/src/helpers/shared.ts
@@ -25,6 +25,7 @@ export const calculateWeight = (label: LabelItem | undefined): number => {
   const matches = label.name.match(/\d+/);
   const number = matches && matches.length > 0 ? parseInt(matches[0]) || 0 : 0;
   if (label.name.toLowerCase().includes("priority")) return number;
+  if (label.name.toLowerCase().includes("minute")) return number * 0.002;
   if (label.name.toLowerCase().includes("hour")) return number * 0.125;
   if (label.name.toLowerCase().includes("day")) return 1 + (number - 1) * 0.25;
   if (label.name.toLowerCase().includes("week")) return number + 1;
@@ -37,6 +38,7 @@ export const calculateDuration = (label: LabelItem): number => {
   const matches = label.name.match(/\d+/);
   if (label.name.toLowerCase().includes("priority")) return 0;
   const number = matches && matches.length > 0 ? parseInt(matches[0]) || 0 : 0;
+  if (label.name.toLowerCase().includes("minute")) return number * 60;
   if (label.name.toLowerCase().includes("hour")) return number * 3600;
   if (label.name.toLowerCase().includes("day")) return number * 86400;
   if (label.name.toLowerCase().includes("week")) return number * 604800;


### PR DESCRIPTION
This PR adds support time labels with minutes, ex: `Time: <5 Minutes`