### PR TITLE
fix: ignore param order for allow

### DIFF
--- a/src/handlers/comment/handlers/allow.ts
+++ b/src/handlers/comment/handlers/allow.ts
@@ -20,40 +20,20 @@ export const setAccess = async (body: string) => {
     return;
   }
 
-  const regex =
-    /^\/allow (?:set-(\S+)\s@(\w+)\s(true|false)|set-(\S+)\s(true|false)\s@(\w+)|(true|false)\sset-(\S+)\s@(\w+)|(true|false)\s@(\w+)\sset-(\S+)|@(\w+)\s(true|false)\sset-(\S+)|@(\w+)\sset-(\S+)\s(true|false))$/;
+  const regex = /\/allow\s+(\S+)\s+(\S+)\s+(\S+)/;
   const matches = body.match(regex);
 
   if (matches) {
     let accessType, username, bool;
-    if (matches[1]) {
-      accessType = matches[1];
-      username = matches[2];
-      bool = matches[3];
-    } else if (matches[4]) {
-      accessType = matches[4];
-      bool = matches[5];
-      username = matches[6];
-    } else if (matches[7]) {
-      bool = matches[7];
-      accessType = matches[8];
-      username = matches[9];
-    } else if (matches[10]) {
-      bool = matches[10];
-      username = matches[11];
-      accessType = matches[12];
-    } else if (matches[13]) {
-      username = matches[13];
-      bool = matches[14];
-      accessType = matches[15];
-    } else if (matches[16]) {
-      username = matches[16];
-      accessType = matches[17];
-      bool = matches[18];
-    } else {
-      bool = username = accessType = "";
+    matches.slice(1).forEach((part) => {
+      if (part.startsWith("@")) username = part.slice(1);
+      else if (part.startsWith("set-")) accessType = part.slice(4);
+      else if (part === "true" || part === "false") bool = part;
+    });
+    if (!accessType || !username || !bool) {
+      logger.error("Invalid body for allow command");
+      return `Invalid syntax for allow \n usage: '/allow set-(access type) @user true|false' \n  ex-1 /allow set-multiplier @user false`;
     }
-
     // Check if access control demand is valid
     if (!validAccessString.includes(accessType)) {
       logger.info(`Access control setting for ${accessType} does not exist.`);

--- a/src/handlers/comment/handlers/allow.ts
+++ b/src/handlers/comment/handlers/allow.ts
@@ -31,25 +31,25 @@ export const setAccess = async (body: string) => {
       username = matches[2];
       bool = matches[3];
     } else if (matches[4]) {
-      username = matches[4];
-      accessType = matches[5];
-      bool = matches[6];
+      accessType = matches[4];
+      bool = matches[5];
+      username = matches[6];
     } else if (matches[7]) {
       bool = matches[7];
       accessType = matches[8];
       username = matches[9];
     } else if (matches[10]) {
-      accessType = matches[10];
-      bool = matches[11];
-      username = matches[12];
+      bool = matches[10];
+      username = matches[11];
+      accessType = matches[12];
     } else if (matches[13]) {
       username = matches[13];
       bool = matches[14];
       accessType = matches[15];
     } else if (matches[16]) {
-      bool = matches[16];
-      username = matches[17];
-      accessType = matches[18];
+      username = matches[16];
+      accessType = matches[17];
+      bool = matches[18];
     } else {
       bool = username = accessType = "";
     }

--- a/src/handlers/comment/handlers/allow.ts
+++ b/src/handlers/comment/handlers/allow.ts
@@ -20,12 +20,39 @@ export const setAccess = async (body: string) => {
     return;
   }
 
-  const regex = /^\/allow set-(\S+)\s@(\S+)\s(true|false)$/;
-
+  const regex =
+    /^\/allow (?:set-(\S+)\s@(\w+)\s(true|false)|set-(\S+)\s(true|false)\s@(\w+)|(true|false)\sset-(\S+)\s@(\w+)|(true|false)\s@(\w+)\sset-(\S+)|@(\w+)\s(true|false)\sset-(\S+)|@(\w+)\sset-(\S+)\s(true|false))$/;
   const matches = body.match(regex);
 
   if (matches) {
-    const [, accessType, username, bool] = matches;
+    let accessType, username, bool;
+    if (matches[1]) {
+      accessType = matches[1];
+      username = matches[2];
+      bool = matches[3];
+    } else if (matches[4]) {
+      username = matches[4];
+      accessType = matches[5];
+      bool = matches[6];
+    } else if (matches[7]) {
+      bool = matches[7];
+      accessType = matches[8];
+      username = matches[9];
+    } else if (matches[10]) {
+      accessType = matches[10];
+      bool = matches[11];
+      username = matches[12];
+    } else if (matches[13]) {
+      username = matches[13];
+      bool = matches[14];
+      accessType = matches[15];
+    } else if (matches[16]) {
+      bool = matches[16];
+      username = matches[17];
+      accessType = matches[18];
+    } else {
+      bool = username = accessType = "";
+    }
 
     // Check if access control demand is valid
     if (!validAccessString.includes(accessType)) {


### PR DESCRIPTION
Resolves #713
QA for https://github.com/ubiquibot/staging/issues/177

The bot that concerns params order for /allow alerts me a message like https://github.com/ubiquibot/staging/issues/176#issuecomment-1706243557
Now I configured the bot to not concern params order and it ignores param order.