### PR TITLE
fix: use bot penalty

### DIFF
--- a/src/handlers/wildcard/unassign.ts
+++ b/src/handlers/wildcard/unassign.ts
@@ -9,9 +9,9 @@ import {
   getReviewRequests,
   listAllIssuesForRepo,
   removeAssignees,
-  wasIssueReopened,
 } from "../../helpers";
-import { Comment, Issue, IssueType, Payload } from "../../types";
+import { Comment, Issue, IssueType, Payload, UserType } from "../../types";
+import { deadLinePrefix } from "../shared";
 
 /**
  * @dev Check out the bounties which haven't been completed within the initial timeline
@@ -67,33 +67,12 @@ const checkBountyToUnassign = async (issue: Issue): Promise<boolean> => {
       logger.info(
         `Unassigning... lastActivityTime: ${lastActivity.getTime()}, curTime: ${curTimestamp}, passedDuration: ${passedDuration}, followUpTime: ${followUpTime}, disqualifyTime: ${disqualifyTime}`
       );
+      await closePullRequestForAnIssue();
+      // remove assignees from the issue
+      await removeAssignees(issue.number, assignees);
+      await addCommentToIssue(`@${assignees[0]} - ${unassignComment} \nLast activity time: ${lastActivity}`, issue.number);
 
-      const wasReopened = await wasIssueReopened(issue.number);
-
-      if (wasReopened) {
-        if (new Date(issue.updated_at).getTime() > lastActivity.getTime()) {
-          logger.info(
-            `Skipping unassigning because #${issue.number} was reopened, lastActivityTime: ${lastActivity.getTime()}, issue.updated_at: ${new Date(
-              issue.updated_at
-            ).getTime()}`
-          );
-          lastActivity.setTime(new Date(issue.updated_at).getTime());
-        } else {
-          await closePullRequestForAnIssue();
-          // remove assignees from the issue
-          await removeAssignees(issue.number, assignees);
-          await addCommentToIssue(`@${assignees[0]} - ${unassignComment} \nLast activity time: ${lastActivity}`, issue.number);
-
-          return true;
-        }
-      } else {
-        await closePullRequestForAnIssue();
-        // remove assignees from the issue
-        await removeAssignees(issue.number, assignees);
-        await addCommentToIssue(`@${assignees[0]} - ${unassignComment} \nLast activity time: ${lastActivity}`, issue.number);
-
-        return true;
-      }
+      return true;
     } else if (passedDuration >= followUpTime) {
       logger.info(
         `Asking for updates... lastActivityTime: ${lastActivity.getTime()}, curTime: ${curTimestamp}, passedDuration: ${passedDuration}, followUpTime: ${followUpTime}, disqualifyTime: ${disqualifyTime}`
@@ -120,6 +99,11 @@ const lastActivityTime = async (issue: Issue, comments: Comment[]): Promise<Date
   logger.info(`Checking the latest activity for the issue, issue_number: ${issue.number}`);
   const assignees = issue.assignees.map((i) => i.login);
   const activities: Date[] = [new Date(issue.created_at)];
+
+  const lastAssignCommentOfHunter = comments
+    .filter((comment) => comment.user.type === UserType.Bot && comment.body.includes(assignees[0]) && comment.body.includes(deadLinePrefix))
+    .sort((a: Comment, b: Comment) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+  if (lastAssignCommentOfHunter.length > 0) activities.push(new Date(lastAssignCommentOfHunter[0].created_at));
 
   // get last comment on the issue
   const lastCommentsOfHunterForIssue = comments

--- a/ubiquibot-config-default.json
+++ b/ubiquibot-config-default.json
@@ -4,10 +4,10 @@
   "issue-creator-multiplier": 2,
   "payment-permit-max-price": 9007199254740991,
   "max-concurrent-assigns": 9007199254740991,
-  "assistive-pricing": true,
-  "disable-analytics": true,
-  "comment-incentives": true,
-  "register-wallet-with-verification": true,
+  "assistive-pricing": false,
+  "disable-analytics": false,
+  "comment-incentives": false,
+  "register-wallet-with-verification": false,
   "stale-bounty-time": "0d",
   "promotion-comment": "\n<h6>If you enjoy the DevPool experience, please follow <a href='https://github.com/ubiquity'>Ubiquity on GitHub</a> and star <a href='https://github.com/ubiquity/devpool-directory'>this repo</a> to show your support. It helps a lot!</h6>",
   "default-labels": [],
@@ -48,35 +48,35 @@
   "command-settings": [
     {
       "name": "start",
-      "enabled": true
+      "enabled": false
     },
     {
       "name": "stop",
-      "enabled": true
+      "enabled": false
     },
     {
       "name": "wallet",
-      "enabled": true
+      "enabled": false
     },
     {
       "name": "payout",
-      "enabled": true
+      "enabled": false
     },
     {
       "name": "multiplier",
-      "enabled": true
+      "enabled": false
     },
     {
       "name": "query",
-      "enabled": true
+      "enabled": false
     },
     {
       "name": "allow",
-      "enabled": true
+      "enabled": false
     },
     {
       "name": "autopay",
-      "enabled": true
+      "enabled": false
     }
   ],
   "incentives": {
@@ -88,7 +88,7 @@
     }
   },
   "enable-access-control": {
-    "label": true,
+    "label": false,
     "organization": true
   }
 }

--- a/ubiquibot-config-default.json
+++ b/ubiquibot-config-default.json
@@ -4,10 +4,10 @@
   "issue-creator-multiplier": 2,
   "payment-permit-max-price": 9007199254740991,
   "max-concurrent-assigns": 9007199254740991,
-  "assistive-pricing": false,
-  "disable-analytics": false,
-  "comment-incentives": false,
-  "register-wallet-with-verification": false,
+  "assistive-pricing": true,
+  "disable-analytics": true,
+  "comment-incentives": true,
+  "register-wallet-with-verification": true,
   "stale-bounty-time": "0d",
   "promotion-comment": "\n<h6>If you enjoy the DevPool experience, please follow <a href='https://github.com/ubiquity'>Ubiquity on GitHub</a> and star <a href='https://github.com/ubiquity/devpool-directory'>this repo</a> to show your support. It helps a lot!</h6>",
   "default-labels": [],
@@ -48,35 +48,35 @@
   "command-settings": [
     {
       "name": "start",
-      "enabled": false
+      "enabled": true
     },
     {
       "name": "stop",
-      "enabled": false
+      "enabled": true
     },
     {
       "name": "wallet",
-      "enabled": false
+      "enabled": true
     },
     {
       "name": "payout",
-      "enabled": false
+      "enabled": true
     },
     {
       "name": "multiplier",
-      "enabled": false
+      "enabled": true
     },
     {
       "name": "query",
-      "enabled": false
+      "enabled": true
     },
     {
       "name": "allow",
-      "enabled": false
+      "enabled": true
     },
     {
       "name": "autopay",
-      "enabled": false
+      "enabled": true
     }
   ],
   "incentives": {
@@ -88,7 +88,7 @@
     }
   },
   "enable-access-control": {
-    "label": false,
+    "label": true,
     "organization": true
   }
 }


### PR DESCRIPTION
Checks if the bot penalty comment created at is more than last activity, if so it returns only the delivery timeline else it will unnassign.

Resolves https://github.com/ubiquity/ubiquibot/issues/681

Example https://github.com/Keyrxng/UbiquityBotTesting/issues/11#issuecomment-1712968225

For testing purposes I added the penalty comment myself to workaround not having setup the backend fully yet but I believe it shows the logic working as intended.

My issue is old enough that it was unassigning me as you'll see with the bot doing so in the interaction list above the comments, after the fix it no longer unassigns.

