### PR TITLE
hotfix: issue creator multiplier should be optional

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -141,7 +141,7 @@ export const WideConfigSchema = Type.Object(
   {
     "evm-network-id": Type.Optional(Type.Number()),
     "price-multiplier": Type.Optional(Type.Number()),
-    "issue-creator-multiplier": Type.Number(),
+    "issue-creator-multiplier": Type.Optional(Type.Number()),
     "time-labels": Type.Optional(Type.Array(LabelItemSchema)),
     "priority-labels": Type.Optional(Type.Array(LabelItemSchema)),
     "payment-permit-max-price": Type.Optional(Type.Number()),


### PR DESCRIPTION
The property should be optional but it was not.