### PR TITLE
fix: hotfix to local build

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint --ext .ts ./src",
     "start:serverless": "tsx src/adapters/github/github-actions.ts",
     "start:watch": "nodemon --exec 'yarn start'",
-    "start": "probot run ./lib/src/index.js",
+    "start": "probot run ./lib/index.js",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- RULES TO CONTRIBUTE TO UBIQUIBOT
   
   1. You must link the issue number e.g. "Resolves #1234"
   2. You must link proof that your code works from a test issue on your forked repo e.g. "Quality Assurance https://github.com/user/repo/issues/1#issuecomment-1"
   3. Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
   
-->

Resolves #796 

Quality Assurance: 

https://github.com/ubiquity/ubiquibot/issues/796#issuecomment-1730921561

latest branch development, on quick `yarn build`, puts `index.js` outside `/src` folder

```typescript
$ probot run ./lib/index.js
INFO (probot): 
INFO (probot): Welcome to Probot!
INFO (probot): Probot is in setup mode, webhooks cannot be received and
INFO (probot): custom routes will not work until APP_ID and PRIVATE_KEY
INFO (probot): are configured in .env.
INFO (probot): Please follow the instructions at http://localhost:3000 to configure .env.
INFO (probot): Once you are done, restart the server.
INFO (probot): 
INFO (server): Running Probot v12.3.1 (Node.js: v20.6.1)
INFO (server): Forwarding https://smee.io/lIAqkpXtACUt1U10 to http://localhost:3000/
INFO (server): Listening on http://localhost:3000
INFO (server): Connected
```