### PR TITLE
feat: reply to invalid config

### DIFF
--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -219,7 +219,7 @@ export const upsertLastCommentToIssue = async (issue_number: number, commentBody
       per_page: 100,
     });
 
-    if (comments.data[comments.data.length - 1].body !== commentBody) await addCommentToIssue(commentBody, issue_number);
+    if (comments.data.length > 0 && comments.data[comments.data.length - 1].body !== commentBody) await addCommentToIssue(commentBody, issue_number);
   } catch (e: unknown) {
     logger.debug(`Upserting last comment failed! reason: ${e}`);
   }

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -207,19 +207,12 @@ export const upsertCommentToIssue = async (issue_number: number, comment: string
 };
 
 export const upsertLastCommentToIssue = async (issue_number: number, commentBody: string) => {
-  const context = getBotContext();
   const logger = getLogger();
-  const payload = context.payload as Payload;
 
   try {
-    const comments = await context.octokit.issues.listComments({
-      owner: payload.repository.owner.login,
-      repo: payload.repository.name,
-      issue_number: issue_number,
-      per_page: 100,
-    });
+    const comments = await getAllIssueComments(issue_number, "json");
 
-    if (comments.data.length > 0 && comments.data[comments.data.length - 1].body !== commentBody) await addCommentToIssue(commentBody, issue_number);
+    if (comments.length > 0 && comments[comments.length - 1].body !== commentBody) await addCommentToIssue(commentBody, issue_number);
   } catch (e: unknown) {
     logger.debug(`Upserting last comment failed! reason: ${e}`);
   }
@@ -280,7 +273,7 @@ export const getIssueDescription = async (issue_number: number, format: "raw" | 
   return result;
 };
 
-export const getAllIssueComments = async (issue_number: number, format: "raw" | "html" | "text" | "full" = "raw"): Promise<Comment[]> => {
+export const getAllIssueComments = async (issue_number: number, format: "raw" | "html" | "text" | "full" | "json" = "raw"): Promise<Comment[]> => {
   const context = getBotContext();
   const payload = context.payload as Payload;
 

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -219,7 +219,7 @@ export const upsertLastCommentToIssue = async (issue_number: number, commentBody
       per_page: 100,
     });
 
-    if (comments.data[comments.data.length - 1].body !== commentBody) addCommentToIssue(commentBody, issue_number);
+    if (comments.data[comments.data.length - 1].body !== commentBody) await addCommentToIssue(commentBody, issue_number);
   } catch (e: unknown) {
     logger.debug(`Upserting last comment failed! reason: ${e}`);
   }

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -206,6 +206,25 @@ export const upsertCommentToIssue = async (issue_number: number, comment: string
   }
 };
 
+export const upsertLastCommentToIssue = async (issue_number: number, commentBody: string) => {
+  const context = getBotContext();
+  const logger = getLogger();
+  const payload = context.payload as Payload;
+
+  try {
+    const comments = await context.octokit.issues.listComments({
+      owner: payload.repository.owner.login,
+      repo: payload.repository.name,
+      issue_number: issue_number,
+      per_page: 100,
+    });
+
+    if (comments.data[comments.data.length - 1].body !== commentBody) addCommentToIssue(commentBody, issue_number);
+  } catch (e: unknown) {
+    logger.debug(`Upserting last comment failed! reason: ${e}`);
+  }
+};
+
 export const getCommentsOfIssue = async (issue_number: number): Promise<Comment[]> => {
   const context = getBotContext();
   const logger = getLogger();

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -210,7 +210,7 @@ export const upsertLastCommentToIssue = async (issue_number: number, commentBody
   const logger = getLogger();
 
   try {
-    const comments = await getAllIssueComments(issue_number, "json");
+    const comments = await getAllIssueComments(issue_number);
 
     if (comments.length > 0 && comments[comments.length - 1].body !== commentBody) await addCommentToIssue(commentBody, issue_number);
   } catch (e: unknown) {
@@ -273,7 +273,7 @@ export const getIssueDescription = async (issue_number: number, format: "raw" | 
   return result;
 };
 
-export const getAllIssueComments = async (issue_number: number, format: "raw" | "html" | "text" | "full" | "json" = "raw"): Promise<Comment[]> => {
+export const getAllIssueComments = async (issue_number: number, format: "raw" | "html" | "text" | "full" = "raw"): Promise<Comment[]> => {
   const context = getBotContext();
   const payload = context.payload as Payload;
 

--- a/src/utils/private.ts
+++ b/src/utils/private.ts
@@ -7,6 +7,7 @@ import merge from "lodash/merge";
 import { DefaultConfig } from "../configs";
 import { validate } from "./ajv";
 import { WideConfig, WideRepoConfig, WideConfigSchema } from "../types";
+import { upsertLastCommentToIssue } from "../helpers";
 
 const CONFIG_REPO = "ubiquibot-config";
 const CONFIG_PATH = ".github/ubiquibot-config.yml";
@@ -110,20 +111,27 @@ const mergeConfigs = (configs: MergedConfigs) => {
 export const getWideConfig = async (context: Context) => {
   const orgConfig = await getConfigSuperset(context, "org", CONFIG_PATH);
   const repoConfig = await getConfigSuperset(context, "repo", CONFIG_PATH);
+  const payload = context.payload as Payload;
 
   const parsedOrg: WideRepoConfig | undefined = parseYAML(orgConfig);
 
   if (parsedOrg) {
     const { valid, error } = validate(WideConfigSchema, parsedOrg);
     if (!valid) {
-      throw new Error(`Invalid org config: ${error}`);
+      const err = new Error(`Invalid org config: ${error}`);
+      if (payload.issue) await upsertLastCommentToIssue(payload.issue.number, err.message);
+      throw err;
     }
   }
+
   const parsedRepo: WideRepoConfig | undefined = parseYAML(repoConfig);
+
   if (parsedRepo) {
     const { valid, error } = validate(WideConfigSchema, parsedRepo);
     if (!valid) {
-      throw new Error(`Invalid repo config: ${error}`);
+      const err = new Error(`Invalid repo config: ${error}`);
+      if (payload.issue) await upsertLastCommentToIssue(payload.issue.number, err.message);
+      throw err;
     }
   }
   const parsedDefault: MergedConfig = DefaultConfig;


### PR DESCRIPTION
The bot replies directly to invocations with invalid config to make it clear why it's down. A new helper method upsertLastCommentToIssue was introduce to avoid adding multpile comments with the same error message.

Resolves: #799

Quality Assurance: https://github.com/gitcoindev/ubiquibot/issues/12
