### PR TITLE
refactor: decrypt PK when it is used

### DIFF
--- a/src/bindings/config.ts
+++ b/src/bindings/config.ts
@@ -60,7 +60,7 @@ export const loadConfig = async (context: Context): Promise<BotConfig> => {
     payout: {
       networkId: networkId,
       rpc: rpc,
-      privateKeyEncrypted: privateKeyEncrypted || "",
+      privateKeyEncrypted: privateKeyEncrypted || null,
       paymentToken: paymentToken,
       permitBaseUrl: process.env.PERMIT_BASE_URL || permitBaseUrl,
     },
@@ -113,7 +113,7 @@ export const loadConfig = async (context: Context): Promise<BotConfig> => {
     newContributorGreeting: newContributorGreeting,
   };
 
-  if (botConfig.payout.privateKeyEncrypted == "") {
+  if (!botConfig.payout.privateKeyEncrypted) {
     botConfig.mode.paymentPermitMaxPrice = 0;
   }
 

--- a/src/bindings/config.ts
+++ b/src/bindings/config.ts
@@ -10,7 +10,7 @@ export const loadConfig = async (context: Context): Promise<BotConfig> => {
   const {
     baseMultiplier,
     timeLabels,
-    privateKey,
+    privateKeyEncrypted,
     priorityLabels,
     incentives,
     paymentPermitMaxPrice,
@@ -60,7 +60,7 @@ export const loadConfig = async (context: Context): Promise<BotConfig> => {
     payout: {
       networkId: networkId,
       rpc: rpc,
-      privateKey: privateKey,
+      privateKeyEncrypted: privateKeyEncrypted || "",
       paymentToken: paymentToken,
       permitBaseUrl: process.env.PERMIT_BASE_URL || permitBaseUrl,
     },
@@ -113,7 +113,7 @@ export const loadConfig = async (context: Context): Promise<BotConfig> => {
     newContributorGreeting: newContributorGreeting,
   };
 
-  if (botConfig.payout.privateKey == "") {
+  if (botConfig.payout.privateKeyEncrypted == "") {
     botConfig.mode.paymentPermitMaxPrice = 0;
   }
 

--- a/src/handlers/payout/action.ts
+++ b/src/handlers/payout/action.ts
@@ -27,7 +27,7 @@ export interface IncentivesCalculationResult {
   paymentToken: string;
   rpc: string;
   networkId: number;
-  privateKey: string;
+  privateKeyEncrypted: string;
   paymentPermitMaxPrice: number;
   baseMultiplier: number;
   incentives: Incentives;
@@ -66,7 +66,7 @@ export interface RewardByUser {
 export const incentivesCalculation = async (): Promise<IncentivesCalculationResult> => {
   const context = getBotContext();
   const {
-    payout: { paymentToken, rpc, permitBaseUrl, networkId, privateKey },
+    payout: { paymentToken, rpc, permitBaseUrl, networkId, privateKeyEncrypted },
     mode: { incentiveMode, paymentPermitMaxPrice },
     price: { incentives, issueCreatorMultiplier, baseMultiplier },
     accessControl,
@@ -147,7 +147,7 @@ export const incentivesCalculation = async (): Promise<IncentivesCalculationResu
     throw new Error("No incentive mode. skipping to process");
   }
 
-  if (privateKey == "") {
+  if (privateKeyEncrypted == "") {
     logger.info("Permit generation disabled because wallet private key is not set.");
     throw new Error("Permit generation disabled because wallet private key is not set.");
   }
@@ -247,7 +247,7 @@ export const incentivesCalculation = async (): Promise<IncentivesCalculationResu
     paymentToken,
     rpc,
     networkId,
-    privateKey,
+    privateKeyEncrypted,
     recipient,
     multiplier,
     paymentPermitMaxPrice,

--- a/src/handlers/payout/action.ts
+++ b/src/handlers/payout/action.ts
@@ -27,7 +27,7 @@ export interface IncentivesCalculationResult {
   paymentToken: string;
   rpc: string;
   networkId: number;
-  privateKeyEncrypted: string;
+  privateKeyEncrypted: string | null;
   paymentPermitMaxPrice: number;
   baseMultiplier: number;
   incentives: Incentives;
@@ -147,7 +147,7 @@ export const incentivesCalculation = async (): Promise<IncentivesCalculationResu
     throw new Error("No incentive mode. skipping to process");
   }
 
-  if (privateKeyEncrypted == "") {
+  if (!privateKeyEncrypted) {
     logger.info("Permit generation disabled because wallet private key is not set.");
     throw new Error("Permit generation disabled because wallet private key is not set.");
   }

--- a/src/helpers/payout.ts
+++ b/src/helpers/payout.ts
@@ -29,7 +29,7 @@ const PAYMENT_TOKEN_PER_NETWORK: Record<string, { rpc: string; token: string }> 
   },
 };
 
-type PayoutConfigPartial = Omit<Static<typeof PayoutConfigSchema>, "networkId" | "privateKey" | "permitBaseUrl">;
+type PayoutConfigPartial = Omit<Static<typeof PayoutConfigSchema>, "networkId" | "privateKeyEncrypted" | "permitBaseUrl">;
 
 /**
  * Returns payout config for a particular network

--- a/src/helpers/permit.ts
+++ b/src/helpers/permit.ts
@@ -5,6 +5,7 @@ import { keccak256, toUtf8Bytes } from "ethers/lib/utils";
 import Decimal from "decimal.js";
 import { Payload } from "../types";
 import { savePermit } from "../adapters/supabase";
+import { getPrivateKey } from "../utils/private";
 
 const PERMIT2_ADDRESS = "0x000000000022D473030F116dDEE9F6B43aC78BA3"; // same on all networks
 
@@ -59,11 +60,13 @@ export const generatePermit2Signature = async (
   userId = ""
 ): Promise<{ txData: TxData; payoutUrl: string }> => {
   const {
-    payout: { networkId, privateKey, permitBaseUrl, rpc, paymentToken },
+    payout: { networkId, privateKeyEncrypted, permitBaseUrl, rpc, paymentToken },
   } = getBotConfig();
   const logger = getLogger();
   const provider = new ethers.providers.JsonRpcProvider(rpc);
-  const adminWallet = new ethers.Wallet(privateKey, provider);
+
+  const privateKeyDecrypted = await getPrivateKey(privateKeyEncrypted);
+  const adminWallet = new ethers.Wallet(privateKeyDecrypted, provider);
 
   const permitTransferFromData: PermitTransferFrom = {
     permitted: {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -76,7 +76,7 @@ export type LogNotification = Static<typeof LogNotificationSchema>;
 export const PayoutConfigSchema = Type.Object({
   networkId: Type.Number(),
   rpc: Type.String(),
-  privateKeyEncrypted: Type.String(),
+  privateKeyEncrypted: Type.Union([Type.Null(), Type.String()]),
   paymentToken: Type.String(),
   permitBaseUrl: Type.String(),
 });

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -76,7 +76,7 @@ export type LogNotification = Static<typeof LogNotificationSchema>;
 export const PayoutConfigSchema = Type.Object({
   networkId: Type.Number(),
   rpc: Type.String(),
-  privateKey: Type.String(),
+  privateKeyEncrypted: Type.String(),
   paymentToken: Type.String(),
   permitBaseUrl: Type.String(),
 });

--- a/src/utils/private.ts
+++ b/src/utils/private.ts
@@ -64,8 +64,10 @@ export const getOrgAndRepoFromPath = (path: string) => {
   return { org, repo };
 };
 
-export const getPrivateKey = async (cipherText: string): Promise<string> => {
+export const getPrivateKey = async (cipherText: string | null): Promise<string> => {
   try {
+    if (!cipherText) throw new Error("Cipher text is empty");
+
     await _sodium.ready;
     const sodium = _sodium;
 


### PR DESCRIPTION
This PR refactors the code so that partner's wallet private key is decrypted only when the payment permit is about to be generated.

**Rationale**

We're about to [expose](https://github.com/ubiquity/ubiquibot-logging/pull/3) the bot's logs to the public. Right now partners' wallets private keys are decrypted on github webhook event. It is pretty easy to leak those PKs via smlth like `logger.info(JSON.stringify(bot.config))`. So this PR makes sure that partners' PKs are encrypted in the initial bot config and decrypted only when necessary (i.e. before the permit generation).

QA issue run with the bot instance from the current PR's branch: https://github.com/rndquu-org/test-repo/issues/48