### PR TITLE
feat: add logs policy

### DIFF
--- a/supabase/migrations/20231018095623_add_logs_policy.sql
+++ b/supabase/migrations/20231018095623_add_logs_policy.sql
@@ -1,0 +1,4 @@
+CREATE POLICY "Enable read access for all users" ON "public"."logs"
+AS PERMISSIVE FOR SELECT
+TO public
+USING (true);


### PR DESCRIPTION
This PR adds a new supabase RLS policy that allows all users to read from the `logs` table. This is required for the [logging app](https://github.com/ubiquity/ubiquibot-logging). If policy is not set then the logger app can't read from the `logs` table using supabase's public anon key.