### PR TITLE
feat: show optional log prefix function name

### DIFF
--- a/src/adapters/supabase/helpers/log.ts
+++ b/src/adapters/supabase/helpers/log.ts
@@ -235,11 +235,11 @@ export class GitHubLogger implements Logger {
   }
 
   info(message: string | object, payload?: JSON) {
-    this.save(payload?.hasOwnProperty("prefix") === true ? this.prefixLogFn() + message : message, LogLevel.INFO, payload);
+    this.save(payload && "prefix" in payload ? this.prefixLogFn() + message : message, LogLevel.INFO, payload);
   }
 
   warn(message: string | object, payload?: JSON) {
-    this.save(payload?.hasOwnProperty("prefix") === true ? this.prefixLogFn() + message : message, LogLevel.WARN, payload);
+    this.save(payload && "prefix" in payload ? this.prefixLogFn() + message : message, LogLevel.WARN, payload);
     this.sendDataWithJwt(message, payload)
       .then((response) => {
         this.save(`Log Notification Success: ${response}`, LogLevel.DEBUG);
@@ -250,11 +250,11 @@ export class GitHubLogger implements Logger {
   }
 
   debug(message: string | object, payload?: JSON) {
-    this.save(payload?.hasOwnProperty("prefix") === true ? this.prefixLogFn() + message : message, LogLevel.DEBUG, payload);
+    this.save(payload && "prefix" in payload ? this.prefixLogFn() + message : message, LogLevel.DEBUG, payload);
   }
 
   error(message: string | object, payload?: JSON) {
-    this.save(payload?.hasOwnProperty("prefix") === true ? this.prefixLogFn() + message : message, LogLevel.ERROR, payload);
+    this.save(payload && "prefix" in payload ? this.prefixLogFn() + message : message, LogLevel.ERROR, payload);
     this.sendDataWithJwt(message, payload)
       .then((response) => {
         this.save(`Log Notification Success: ${response}`, LogLevel.DEBUG);

--- a/src/bindings/event.ts
+++ b/src/bindings/event.ts
@@ -27,6 +27,7 @@ export type Logger = {
 
 let logger: Logger;
 export const getLogger = (): Logger => logger;
+export const logFnName = <JSON>(<unknown>{ prefix: true });
 
 const NO_VALIDATION = [GithubEvent.INSTALLATION_ADDED_EVENT as string, GithubEvent.PUSH_EVENT as string];
 

--- a/src/handlers/label/index.ts
+++ b/src/handlers/label/index.ts
@@ -1,5 +1,5 @@
 import { saveLabelChange } from "../../adapters/supabase";
-import { getBotContext, getLogger } from "../../bindings";
+import { getBotContext, getLogger, logFnName } from "../../bindings";
 import { hasLabelEditPermission } from "../../helpers";
 import { Payload } from "../../types";
 
@@ -18,7 +18,7 @@ export const watchLabelChange = async () => {
   const triggerUser = sender.login;
 
   if (!previousLabel || !currentLabel) {
-    logger.debug("watchLabelChange: No label name change.. skipping");
+    logger.debug("No label name change.. skipping", logFnName);
     return;
   }
 
@@ -26,5 +26,5 @@ export const watchLabelChange = async () => {
   const hasAccess = await hasLabelEditPermission(currentLabel, triggerUser, repository.full_name);
 
   await saveLabelChange(triggerUser, full_name, previousLabel, currentLabel, hasAccess);
-  logger.debug("watchLabelChange: label name change saved to db");
+  logger.debug("label name change saved to db", logFnName);
 };


### PR DESCRIPTION
Refactor the log function so that redundant prefixes passing in are removed. Those should be automatically derived from the stack trace.

The prefixes can be optionally enabled for any log function.

Resolves: #665

Quality Assurance (a few example function name prefixes added in square brackets): 

![image](https://github.com/ubiquity/ubiquibot/assets/88761781/15f95d01-f354-4342-b6bd-376f00d06fda)

